### PR TITLE
Copy 'breaking-change' and 'momentOfTruth' from 'azure-rest-api-specs'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+dist/
+package-lock.json

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,22 @@
+trigger:
+- master
+
+jobs:
+- job: Build
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  steps:
+  - task: Npm@1
+    displayName: 'npm pack'
+    inputs:
+      command: custom
+      verbose: false
+      customCommand: pack
+  - task: CopyFiles@2
+    displayName: 'Copy Files to: drop'
+    inputs:
+      Contents: '*.tgz'
+      TargetFolder: drop
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: $(Build.SourcesDirectory)/drop

--- a/package.json
+++ b/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@azure/rest-api-specs-scripts",
+  "version": "0.1.0",
+  "description": "Scripts for the Azure RestAPI specification repository 'azure-rest-api-specs'.",
+  "types": "dist/index.d.ts",
+  "main": "dist/index.js",
+  "files": [
+    "dist/",
+    "src/"
+  ],
+  "scripts": {
+    "tsc": "tsc",
+    "test": "tsc",
+    "pack": "tsc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Azure/rest-api-specs-scripts.git"
+  },
+  "author": "Microsoft Corporation",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Azure/rest-api-specs-scripts/issues"
+  },
+  "homepage": "https://github.com/Azure/rest-api-specs-scripts#readme",
+  "devDependencies": {
+    "@types/fs-extra": "^5.0.5",
+    "@types/glob": "^7.1.1",
+    "@types/js-yaml": "^3.12.1",
+    "@types/node": "^11.13.4",
+    "@types/request": "^2.48.1",
+    "typescript": "^3.4.3"
+  },
+  "dependencies": {
+    "@azure/oad": "^0.5.1",
+    "@ts-common/string-map": "^0.3.0",
+    "fs-extra": "^7.0.1",
+    "glob": "^7.1.3",
+    "js-yaml": "^3.13.1",
+    "request": "^2.88.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "tsc": "tsc",
     "test": "tsc",
-    "pack": "tsc"
+    "pack": "npm install && tsc"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@azure/rest-api-specs-scripts",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Scripts for the Azure RestAPI specification repository 'azure-rest-api-specs'.",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
   "files": [
     "dist/",
-    "src/"
+    "src/",
+    "tsconfig.json"
   ],
   "scripts": {
     "tsc": "tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/rest-api-specs-scripts",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Scripts for the Azure RestAPI specification repository 'azure-rest-api-specs'.",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/rest-api-specs-scripts",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Scripts for the Azure RestAPI specification repository 'azure-rest-api-specs'.",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "dist/index.js",
   "files": [
     "dist/",
-    "src/"
+    "src/",
+    "tsconfig.json"
   ],
   "scripts": {
     "tsc": "tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/rest-api-specs-scripts",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Scripts for the Azure RestAPI specification repository 'azure-rest-api-specs'.",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/rest-api-specs-scripts",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Scripts for the Azure RestAPI specification repository 'azure-rest-api-specs'.",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,12 @@
 {
   "name": "@azure/rest-api-specs-scripts",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Scripts for the Azure RestAPI specification repository 'azure-rest-api-specs'.",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
   "files": [
     "dist/",
-    "src/",
-    "tsconfig.json"
+    "src/"
   ],
   "scripts": {
     "tsc": "tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/rest-api-specs-scripts",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Scripts for the Azure RestAPI specification repository 'azure-rest-api-specs'.",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
@@ -11,7 +11,7 @@
   "scripts": {
     "tsc": "tsc",
     "test": "tsc",
-    "pack": "npm install && tsc"
+    "prepack": "npm install && tsc"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/rest-api-specs-scripts",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Scripts for the Azure RestAPI specification repository 'azure-rest-api-specs'.",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "main": "dist/index.js",
   "files": [
     "dist/",
-    "src/",
-    "tsconfig.json"
+    "src/"
   ],
   "scripts": {
     "tsc": "tsc",

--- a/src/breaking-change.ts
+++ b/src/breaking-change.ts
@@ -1,0 +1,239 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License in the project root for license information.
+
+import * as stringMap from '@ts-common/string-map'
+import * as tsUtils from './ts-utils'
+import * as utils from './utils'
+import * as path from 'path'
+import * as fs from 'fs-extra'
+import * as os from 'os'
+import * as childProcess from 'child_process'
+import * as oad from '@azure/oad'
+import * as util from 'util'
+
+const exec = util.promisify(childProcess.exec)
+
+// This map is used to store the mapping between files resolved and stored location
+var resolvedMapForNewSpecs: stringMap.MutableStringMap<string> = {};
+let outputFolder = path.join(os.tmpdir(), "resolved");
+// Used to enable running script outside TravisCI for debugging
+let isRunningInTravisCI = process.env.TRAVIS === 'true';
+
+const headerText = `
+| | Rule | Location | Message |
+|-|------|----------|---------|
+`;
+
+function iconFor(type: unknown) {
+  if (type === 'Error') {
+    return ':x:';
+  } else if (type === 'Warning') {
+    return ':warning:';
+  } else if (type === 'Info') {
+    return ':speech_balloon:';
+  } else {
+    return '';
+  }
+}
+
+function shortName(filePath: string) {
+  return `${path.basename(path.dirname(filePath))}/&#8203;<strong>${path.basename(filePath)}</strong>`;
+}
+
+type Diff = {
+  readonly type: unknown
+  readonly id: string
+  readonly code: unknown
+  readonly message: unknown
+}
+
+function tableLine(filePath: string, diff: Diff) {
+  return `|${iconFor(diff['type'])}|[${diff['type']} ${diff['id']} - ${diff['code']}](https://github.com/Azure/openapi-diff/blob/master/docs/rules/${diff['id']}.md)|[${shortName(filePath)}](${blobHref(filePath)} "${filePath}")|${diff['message']}|\n`;
+}
+
+function blobHref(file: unknown) {
+  return `https://github.com/${process.env.TRAVIS_PULL_REQUEST_SLUG}/blob/${process.env.TRAVIS_PULL_REQUEST_SHA}/${file}`;
+}
+
+/**
+ * Compares old and new specifications for breaking change detection.
+ *
+ * @param oldSpec Path to the old swagger specification file.
+ *
+ * @param newSpec Path to the new swagger specification file.
+ */
+async function runOad(oldSpec: string, newSpec: string) {
+  if (oldSpec === null || oldSpec === undefined || typeof oldSpec.valueOf() !== 'string' || !oldSpec.trim().length) {
+    throw new Error('oldSpec is a required parameter of type "string" and it cannot be an empty string.');
+  }
+
+  if (newSpec === null || newSpec === undefined || typeof newSpec.valueOf() !== 'string' || !newSpec.trim().length) {
+    throw new Error('newSpec is a required parameter of type "string" and it cannot be an empty string.');
+  }
+
+  console.log(`>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>`);
+  console.log(`Old Spec: "${oldSpec}"`);
+  console.log(`New Spec: "${newSpec}"`);
+  console.log(`>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>`);
+
+  let result = await oad.compare(oldSpec, newSpec, { consoleLogLevel: 'warn' });
+  console.log(result);
+
+  if (!result) {
+    return;
+  }
+
+  // fix up output from OAD, it does not output valid JSON
+  result = '[' + result.replace(/}\s+{/gi,"},{") + ']'
+
+  return JSON.parse(result);
+}
+
+/**
+ * Processes the given swagger and stores the resolved swagger on to disk
+ *
+ * @param swaggerPath Path to the swagger specification file.
+ */
+async function processViaAutoRest(swaggerPath: string) {
+  if (swaggerPath === null || swaggerPath === undefined || typeof swaggerPath.valueOf() !== 'string' || !swaggerPath.trim().length) {
+    throw new Error('swaggerPath is a required parameter of type "string" and it cannot be an empty string.');
+  }
+
+  const swaggerOutputFolder = path.join(outputFolder, path.dirname(swaggerPath));
+  const swaggerOutputFileNameWithoutExt = path.basename(swaggerPath, '.json');
+  const autoRestCmd = `autorest --input-file=${swaggerPath} --output-artifact=swagger-document.json --output-file=${swaggerOutputFileNameWithoutExt} --output-folder=${swaggerOutputFolder}`;
+
+  console.log(`Executing : ${autoRestCmd}`);
+
+  try {
+    await fs.ensureDir(swaggerOutputFolder);
+    await exec(`${autoRestCmd}`, { encoding: 'utf8', maxBuffer: 1024 * 1024 * 64 });
+    resolvedMapForNewSpecs[swaggerPath] = path.join(swaggerOutputFolder, swaggerOutputFileNameWithoutExt + '.json');
+  } catch (err) {
+    console.log(`Error processing via AutoRest: ${err}`);
+  }
+}
+
+//main function
+export async function runScript() {
+  // See whether script is in Travis CI context
+  console.log(`isRunningInTravisCI: ${isRunningInTravisCI}`);
+
+  let targetBranch = utils.getTargetBranch();
+  let swaggersToProcess = utils.getFilesChangedInPR();
+
+  console.log('Processing swaggers:');
+  console.log(swaggersToProcess);
+
+  console.log('Finding new swaggers...')
+  let newSwaggers: unknown[] = [];
+  if (isRunningInTravisCI && swaggersToProcess.length > 0) {
+    newSwaggers = await utils.doOnBranch(utils.getTargetBranch(), async () => {
+      return swaggersToProcess.filter((s: string) => !fs.existsSync(s))
+    });
+  }
+
+  console.log('Processing via AutoRest...');
+  for (const swagger of swaggersToProcess) {
+    if (!newSwaggers.includes(swagger)) {
+      await processViaAutoRest(swagger);
+    }
+  }
+
+  console.log(`Resolved map for the new specifications:`);
+  console.dir(resolvedMapForNewSpecs);
+
+  let errors = 0, warnings = 0;
+  const diffFiles: stringMap.MutableStringMap<Diff[]> = {};
+  const newFiles = [];
+
+  for (const swagger of swaggersToProcess) {
+    // If file does not exists in the previous commits then we ignore it as it's new file
+    if (newSwaggers.includes(swagger)) {
+      console.log(`File: "${swagger}" looks to be newly added in this PR.`);
+      newFiles.push(swagger);
+      continue;
+    }
+
+    const resolved = resolvedMapForNewSpecs[swagger]
+    if (resolved) {
+      const diffs = await runOad(swagger, resolved);
+      if (diffs) {
+        diffFiles[swagger] = diffs;
+        for (const diff of diffs) {
+          if (diff['type'] === 'Error') {
+            if (errors === 0) {
+              console.log(`There are potential breaking changes in this PR. Please review before moving forward. Thanks!`);
+              process.exitCode = 1;
+            }
+            errors += 1;
+          } else if (diff['type'] === 'Warning') {
+            warnings += 1;
+          }
+        }
+      }
+    }
+  }
+
+  if (isRunningInTravisCI) {
+    let summary = '';
+    if (errors > 0) {
+      summary += '**There are potential breaking changes in this PR. Please review before moving forward. Thanks!**\n\n';
+    }
+    summary += `Compared to the target branch (**${targetBranch}**), this pull request introduces:\n\n`;
+    summary += `&nbsp;&nbsp;&nbsp;${errors > 0 ? iconFor('Error') : ':white_check_mark:'}&nbsp;&nbsp;&nbsp;**${errors}** new error${errors !== 1 ? 's' : ''}\n\n`;
+    summary += `&nbsp;&nbsp;&nbsp;${warnings > 0 ? iconFor('Warning') : ':white_check_mark:'}&nbsp;&nbsp;&nbsp;**${warnings}** new warning${warnings !== 1 ? 's' : ''}\n\n`;
+
+    let message = '';
+    if (newFiles.length > 0) {
+      message += '### The following files look to be newly added in this PR:\n';
+      newFiles.sort();
+      for (const swagger of newFiles) {
+        message += `* [${swagger}](${blobHref(swagger)})\n`;
+      }
+      message += '<br><br>\n';
+    }
+
+    const diffFileNames = Object.keys(diffFiles);
+    if (diffFileNames.length > 0) {
+      message += '### OpenAPI diff results\n';
+      message += headerText;
+
+      diffFileNames.sort();
+      for (const swagger of diffFileNames) {
+        const diffs = tsUtils.asNonUndefined(diffFiles[swagger]);
+        diffs.sort((a, b) => {
+          if (a.type === b.type) {
+            return a.id.localeCompare(b.id);
+          } else if (a.type === "Error") {
+            return 1;
+          } else if (b.type === "Error") {
+            return -1;
+          } else if (a.type === "Warning") {
+            return 1;
+          } else {
+            return -1;
+          }
+        });
+
+        for (const diff of diffs) {
+          message += tableLine(swagger, diff);
+        }
+      }
+    } else {
+      message += '**There were no files containing new errors or warnings.**\n';
+    }
+
+    message += '\n<br><br>\nThanks for using breaking change tool to review.\nIf you encounter any issue(s), please open issue(s) at https://github.com/Azure/openapi-diff/issues.';
+
+    const output = {
+      title: `${errors === 0 ? 'No' : errors} potential breaking change${errors !== 1 ? 's' : ''}`,
+      summary,
+      text: message
+    };
+
+    console.log('---output');
+    console.log(JSON.stringify(output));
+    console.log('---');
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@
 // Licensed under the MIT License. See License in the project root for license information.
 
 export { runScript as breakingChange } from './breaking-change'
+export { runScript as momentOfTruth } from './momentOfTruth'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License in the project root for license information.
+
+export { runScript as breakingChange } from './breaking-change'

--- a/src/momentOfTruth.ts
+++ b/src/momentOfTruth.ts
@@ -28,7 +28,7 @@ var finalResult: FinalResult = {
 
 // Creates and returns path to the logging directory
 function getLogDir() {
-    let logDir = path.join(__dirname, '../', 'output');
+    let logDir = path.resolve('output');
     if (!fs.existsSync(logDir)) {
         try {
             fs.mkdirSync(logDir);

--- a/src/momentOfTruth.ts
+++ b/src/momentOfTruth.ts
@@ -1,0 +1,137 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+import * as stringMap from '@ts-common/string-map'
+import * as tsUtils from './ts-utils'
+import { exec } from 'child_process'
+import * as path from 'path'
+import * as utils from './utils'
+import * as fs from 'fs'
+
+let configsToProcess = utils.getConfigFilesChangedInPR();
+let pullRequestNumber = utils.getPullRequestNumber();
+let linterCmd = `npx autorest --validation --azure-validator --message-format=json `;
+var filename = `${pullRequestNumber}.json`;
+var logFilepath = path.join(getLogDir(), filename);
+
+type FinalResult = {
+    readonly pullRequest: unknown,
+    readonly repositoryUrl: unknown,
+    readonly files: stringMap.MutableStringMap<stringMap.MutableStringMap<unknown>>
+}
+
+var finalResult: FinalResult = {
+    pullRequest: pullRequestNumber,
+    repositoryUrl: utils.getRepoUrl(),
+    files: {}
+}
+
+// Creates and returns path to the logging directory
+function getLogDir() {
+    let logDir = path.join(__dirname, '../', 'output');
+    if (!fs.existsSync(logDir)) {
+        try {
+            fs.mkdirSync(logDir);
+        } catch (e) {
+            if (e.code !== 'EEXIST') throw e;
+        }
+    }
+    return logDir;
+}
+
+//creates the log file if it has not been created
+function createLogFile() {
+    if (!fs.existsSync(logFilepath)) {
+        fs.writeFileSync(logFilepath, '');
+    }
+}
+
+//appends the content to the log file
+function writeContent(content: unknown) {
+    fs.writeFileSync(logFilepath, content);
+}
+
+// Executes linter on given swagger path and returns structured JSON of linter output
+async function getLinterResult(swaggerPath: string|null|undefined) {
+    if (swaggerPath === null || swaggerPath === undefined || typeof swaggerPath.valueOf() !== 'string' || !swaggerPath.trim().length) {
+        throw new Error('swaggerPath is a required parameter of type "string" and it cannot be an empty string.');
+    }
+
+    let jsonResult = [];
+    if (!fs.existsSync(swaggerPath)) {
+        return [];
+    }
+    let cmd = "npx autorest --reset && " + linterCmd + swaggerPath;
+    console.log(`Executing: ${cmd}`);
+    const { err, stdout, stderr } = await new Promise(res => exec(cmd, { encoding: 'utf8', maxBuffer: 1024 * 1024 * 64 },
+        (err: unknown, stdout: unknown, stderr: unknown) => res({ err: err, stdout: stdout, stderr: stderr })));
+
+    if (err && stderr.indexOf("Process() cancelled due to exception") !== -1) {
+        console.error(`AutoRest exited with code ${err.code}`);
+        console.error(stderr);
+        throw new Error("AutoRest failed");
+    }
+
+    let resultString = stdout + stderr;
+    if (resultString.indexOf('{') !== -1) {
+        resultString = resultString.replace(/Processing batch task - {.*} \.\n/g, "");
+        resultString = "[" + resultString.substring(resultString.indexOf('{')).trim().replace(/\}\n\{/g, "},\n{") + "]";
+        //console.log('>>>>>> Trimmed Result...');
+        //console.log(resultString);
+        try {
+            jsonResult = JSON.parse(resultString);
+            //console.log('>>>>>> Parsed Result...');
+            //console.dir(resultObject, {depth: null, colors: true});
+            return jsonResult;
+        } catch (e) {
+            console.error(`An error occurred while executing JSON.parse() on the linter output for ${swaggerPath}:`);
+            console.dir(resultString);
+            console.dir(e, { depth: null, colors: true });
+            process.exit(1)
+        }
+    }
+    return [];
+};
+
+// Run linter tool
+async function runTools(swagger: string, beforeOrAfter: string) {
+    console.log(`Processing "${swagger}":`);
+    const linterErrors = await getLinterResult(swagger);
+    console.log(linterErrors);
+    await updateResult(swagger, linterErrors, beforeOrAfter);
+};
+
+// Updates final result json to be written to the output file
+async function updateResult(spec: string, errors: unknown, beforeOrAfter: string) {
+    const files = finalResult['files']
+    if (!files[spec]) {
+        files[spec] = {};
+    }
+    const filesSpec = tsUtils.asNonUndefined(files[spec])
+    if (!filesSpec[beforeOrAfter]) {
+        filesSpec[beforeOrAfter] = {};
+    }
+    filesSpec[beforeOrAfter] = errors;
+}
+
+//main function
+export async function runScript() {
+    console.log('Processing configs:');
+    console.log(configsToProcess);
+    createLogFile();
+    console.log(`The results will be logged here: "${logFilepath}".`)
+
+    if (configsToProcess.length > 0) {
+        for (const configFile of configsToProcess) {
+            await runTools(configFile, 'after');
+        }
+
+        await utils.doOnBranch(utils.getTargetBranch(), async () => {
+            for (const configFile of configsToProcess) {
+                await runTools(configFile, 'before');
+            }
+        });
+    }
+
+    writeContent(JSON.stringify(finalResult, null, 2));
+}

--- a/src/ts-utils.ts
+++ b/src/ts-utils.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License in the project root for license information.
+
+export const asNonUndefined = <T>(v: T|undefined) => v as T

--- a/src/ts-utils.ts
+++ b/src/ts-utils.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License in the project root for license information.
 
-export const asNonUndefined = <T>(v: T|undefined) => v as T
+export dddconst asNonUndefined = <T>(v: T|undefined) => v as T

--- a/src/ts-utils.ts
+++ b/src/ts-utils.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License in the project root for license information.
 
-export dddconst asNonUndefined = <T>(v: T|undefined) => v as T
+export const asNonUndefined = <T>(v: T|undefined) => v as T

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,347 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License in the project root for license information.
+
+import * as tsUtils from './ts-utils'
+import * as stringMap from '@ts-common/string-map'
+import * as os from 'os'
+import * as fs from 'fs-extra'
+import * as glob from 'glob'
+import * as path from 'path'
+const z = require('z-schema')
+import * as YAML from 'js-yaml'
+import request = require('request')
+import * as util from 'util'
+import { execSync } from 'child_process'
+
+const asyncJsonRequest = (url: string) => new Promise<unknown>((res, rej) => request(
+  { url, json: true },
+  (error: unknown, _: unknown, body: unknown) => error ? rej(error) : res(body)
+));
+
+export const extensionSwaggerSchemaUrl = "https://raw.githubusercontent.com/Azure/autorest/master/schema/swagger-extensions.json";
+export const swaggerSchemaUrl = "http://json.schemastore.org/swagger-2.0";
+export const swaggerSchemaAltUrl = "http://swagger.io/v2/schema.json";
+export const schemaUrl = "http://json-schema.org/draft-04/schema";
+export const exampleSchemaUrl = "https://raw.githubusercontent.com/Azure/autorest/master/schema/example-schema.json";
+export const compositeSchemaUrl = "https://raw.githubusercontent.com/Azure/autorest/master/schema/composite-swagger.json";
+
+export const isWindows = (process.platform.lastIndexOf('win') === 0);
+export const prOnly = undefined !== process.env['PR_ONLY'] ? process.env['PR_ONLY'] : 'false';
+
+export const globPath = path.join(__dirname, '../', '../', '/specification/**/*.json');
+export const swaggers = glob.sync(globPath, { ignore: ['**/examples/**/*.json', '**/quickstart-templates/*.json', '**/schema/*.json'] });
+export const exampleGlobPath = path.join(__dirname, '../', '../', '/specification/**/examples/**/*.json');
+export const examples = glob.sync(exampleGlobPath);
+export const readmes = glob.sync(path.join(__dirname, '../', '../', '/specification/**/readme.md'));
+
+// Remove byte order marker. This catches EF BB BF (the UTF-8 BOM)
+// because the buffer-to-string conversion in `fs.readFile()`
+// translates it to FEFF, the UTF-16 BOM.
+export const stripBOM = function(content: Buffer|string) {
+  if (Buffer.isBuffer(content)) {
+    content = content.toString();
+  }
+  if (content.charCodeAt(0) === 0xFEFF || content.charCodeAt(0) === 0xFFFE) {
+    content = content.slice(1);
+  }
+  return content;
+};
+
+/**
+ * Parses the json from the given filepath
+ * @returns {string} clr command
+ */
+export const parseJsonFromFile = async function(filepath: string) {
+  const data = await fs.readFile(filepath, { encoding: 'utf8' });
+  try {
+    return YAML.safeLoad(stripBOM(data));
+  } catch (error) {
+    throw new Error(`swagger "${filepath}" is an invalid JSON.\n${util.inspect(error, { depth: null })}`);
+  }
+};
+
+/**
+ * Gets the name of the target branch to which the PR is sent. We are using the environment
+ * variable provided by travis-ci. It is called TRAVIS_BRANCH. More info can be found here:
+ * https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
+ * If the environment variable is undefined then the method returns 'master' as the default value.
+ * @returns {string} branchName The target branch name.
+ */
+export const getTargetBranch = function() {
+  console.log(`@@@@@ process.env['TRAVIS_BRANCH'] - ${process.env['TRAVIS_BRANCH']}`);
+  let result = process.env['TRAVIS_BRANCH'] || 'master';
+  result = result.trim();
+  console.log(`>>>>> The target branch is: "${result}".`);
+  return result;
+};
+
+/**
+ * Check out a copy of a branch to a temporary location, execute a function, and then restore the previous state
+ */
+export const doOnBranch = async function<T>(branch: unknown, func: () => Promise<T>) {
+  fetchBranch(branch);
+  const branchSha = resolveRef(`origin/${branch}`);
+  const tmpDir = path.join(os.tmpdir(), branchSha);
+
+  const currentDir = process.cwd();
+  checkoutBranch(branch, tmpDir);
+
+  console.log(`Changing directory and executing the function...`);
+  process.chdir(tmpDir);
+  const result = await func();
+
+  console.log(`Restoring previous directory and deleting secondary working tree...`);
+  process.chdir(currentDir);
+  execSync(`rm -rf ${tmpDir}`);
+
+  return result;
+}
+
+/**
+ * Resolve a ref to its commit hash
+ */
+export const resolveRef = function(ref: unknown) {
+  let cmd = `git rev-parse ${ref}`;
+  console.log(`> ${cmd}`);
+  return execSync(cmd, { encoding: 'utf8' }).trim();
+}
+
+/**
+ * Fetch ref for a branch from the origin
+ */
+export const fetchBranch = function(branch: unknown) {
+  let cmds = [
+    `git remote -vv`,
+    `git branch --all`,
+    `git remote set-branches origin --add ${branch}`,
+    `git fetch origin ${branch}`
+  ];
+
+  console.log(`Fetching branch ${branch} from origin...`);
+  for (let cmd of cmds) {
+    console.log(`> ${cmd}`);
+    execSync(cmd, { encoding: 'utf8', stdio: 'inherit' });
+  }
+}
+
+/**
+ * Checkout a copy of branch to location
+ */
+export const checkoutBranch = function(ref: unknown, location: unknown) {
+  let cmd = `git worktree add -f ${location} origin/${ref}`;
+  console.log(`Checking out a copy of branch ${ref} to ${location}...`);
+  console.log(`> ${cmd}`);
+  execSync(cmd, { encoding: 'utf8', stdio: 'inherit' });
+}
+
+/**
+ * Gets the name of the source branch from which the PR is sent.
+ * @returns {string} branchName The source branch name.
+ */
+export const getSourceBranch = function() {
+  let cmd = 'git rev-parse --abbrev-ref HEAD';
+  let result = process.env['TRAVIS_PULL_REQUEST_BRANCH'];
+  console.log(`@@@@@ process.env['TRAVIS_PULL_REQUEST_BRANCH'] - ${process.env['TRAVIS_PULL_REQUEST_BRANCH']}`);
+  if (!result) {
+    try {
+      result = execSync(cmd, { encoding: 'utf8' });
+    } catch (err) {
+      console.log(`An error occurred while getting the current branch ${util.inspect(err, { depth: null })}.`);
+    }
+  }
+  result = tsUtils.asNonUndefined(result).trim();
+  console.log(`>>>>> The source branch is: "${result}".`);
+  return result;
+};
+
+/**
+ * Gets the PR number. We are using the environment
+ * variable provided by travis-ci. It is called TRAVIS_PULL_REQUEST. More info can be found here:
+ * https://docs.travis-ci.com/user/environment-variables/#Convenience-Variables
+ * @returns {string} PR number or 'undefined'.
+ */
+export const getPullRequestNumber = function() {
+  let result = process.env['TRAVIS_PULL_REQUEST'];
+  console.log(`@@@@@ process.env['TRAVIS_PULL_REQUEST'] - ${process.env['TRAVIS_PULL_REQUEST']}`);
+
+  if (!result) {
+    result = 'undefined';
+  }
+
+  return result;
+};
+
+/**
+ * Gets the Repo name. We are using the environment
+ * variable provided by travis-ci. It is called TRAVIS_REPO_SLUG. More info can be found here:
+ * https://docs.travis-ci.com/user/environment-variables/#Convenience-Variables
+ * @returns {string} repo name or 'undefined'.
+ */
+export const getRepoName = function() {
+  let result = process.env['TRAVIS_REPO_SLUG'];
+  console.log(`@@@@@ process.env['TRAVIS_REPO_SLUG'] - ${result}`);
+
+  return result;
+};
+
+/**
+ * Gets the source repo name for PR's. We are using the environment
+ * variable provided by travis-ci. It is called TRAVIS_PULL_REQUEST_SLUG. More info can be found here:
+ * https://docs.travis-ci.com/user/environment-variables/#Convenience-Variables
+ * @returns {string} repo name or 'undefined'.
+ */
+export const getSourceRepoName = function() {
+  let result = process.env['TRAVIS_PULL_REQUEST_SLUG'];
+  console.log(`@@@@@ process.env['TRAVIS_PULL_REQUEST_SLUG'] - ${result}`);
+
+  return result;
+};
+
+// Retrieves Git Repository Url
+/**
+ * Gets the repo URL
+ * @returns {string} repo URL or 'undefined'
+ */
+export const getRepoUrl = function() {
+  let repoName = getRepoName();
+  return `https://github.com/${repoName}`;
+};
+
+// Retrieves the source Git Repository Url
+/**
+ * Gets the repo URL from where the PR originated
+ * @returns {string} repo URL or 'undefined'
+ */
+export const getSourceRepoUrl = function() {
+  let repoName = getSourceRepoName();
+  return `https://github.com/${repoName}`;
+};
+
+export const getTimeStamp = function() {
+  // We pad each value so that sorted directory listings show the files in chronological order
+  function pad(number: any): any {
+    if (number < 10) {
+      return '0' + number;
+    }
+
+    return number;
+  }
+
+  var now = new Date();
+  return now.getFullYear()
+    + pad(now.getMonth() + 1)
+    + pad(now.getDate())
+    + "_"
+    + pad(now.getHours())
+    + pad(now.getMinutes())
+    + pad(now.getSeconds());
+}
+
+/**
+ * Retrieves list of swagger files to be processed for linting
+ * @returns {Array} list of files to be processed for linting
+ */
+export const getConfigFilesChangedInPR = function() {
+  if (prOnly === 'true') {
+    let targetBranch, cmd, filesChanged;
+    try {
+      targetBranch = getTargetBranch();
+      execSync(`git fetch origin ${targetBranch}`);
+      cmd = `git diff --name-only HEAD $(git merge-base HEAD FETCH_HEAD)`;
+      filesChanged = execSync(cmd, { encoding: 'utf8' }).split('\n');
+      console.log('>>>>> Files changed in this PR are as follows:');
+      console.log(filesChanged);
+
+      // traverse up to readme.md files
+      const configFiles = new Set();
+      for (let fileChanged of filesChanged) {
+        while (fileChanged.startsWith("specification")) {
+          if (fileChanged.toLowerCase().endsWith("readme.md") && fs.existsSync(fileChanged)) {
+            configFiles.add(fileChanged);
+            break;
+          }
+          // select parent readme
+          const parts = fileChanged.split('/');
+          parts.pop();
+          parts.pop();
+          parts.push("readme.md");
+          fileChanged = parts.join('/');
+        }
+      }
+      filesChanged = [...configFiles.values()];
+
+      console.log('>>>>> Affected configuration files:');
+      console.log(filesChanged);
+
+      return filesChanged;
+    } catch (err) {
+      throw err;
+    }
+  } else {
+    return swaggers;
+  }
+};
+
+/**
+ * Retrieves list of swagger files to be processed for linting
+ * @returns {Array} list of files to be processed for linting
+ */
+export const getFilesChangedInPR = function() {
+  let result = swaggers;
+  if (prOnly === 'true') {
+    let targetBranch, cmd, filesChanged, swaggerFilesInPR;
+    try {
+      targetBranch = getTargetBranch();
+      execSync(`git fetch origin ${targetBranch}`);
+      cmd = `git diff --name-only HEAD $(git merge-base HEAD FETCH_HEAD)`;
+      filesChanged = execSync(cmd, { encoding: 'utf8' });
+      console.log('>>>>> Files changed in this PR are as follows:')
+      console.log(filesChanged);
+      swaggerFilesInPR = filesChanged.split('\n').filter(function (item: string) {
+        if (item.match(/.*(json|yaml)$/ig) == null || item.match(/.*specification.*/ig) == null) {
+          return false;
+        }
+        if (item.match(/.*\/examples\/*/ig) !== null) {
+          return false;
+        }
+        if (item.match(/.*\/quickstart-templates\/*/ig) !== null) {
+          return false;
+        }
+        return true;
+      });
+      console.log(`>>>> Number of swaggers found in this PR: ${swaggerFilesInPR.length}`);
+
+      var deletedFiles = swaggerFilesInPR.filter(function (swaggerFile: string) {
+        return !fs.existsSync(swaggerFile);
+      });
+      console.log('>>>>> Files deleted in this PR are as follows:')
+      console.log(deletedFiles);
+      // Remove files that have been deleted in the PR
+      swaggerFilesInPR = swaggerFilesInPR.filter(function (x: string) { return deletedFiles.indexOf(x) < 0 });
+
+      result = swaggerFilesInPR;
+    } catch (err) {
+      throw err;
+    }
+  }
+  return result;
+};
+
+/**
+ * Downloads the remote schemas and initializes the validator with remote references.
+ * @returns {Object} context Provides the schemas in json format and the validator.
+ */
+export const initializeValidator = async function() {
+  const context: stringMap.MutableStringMap<unknown> = {
+    extensionSwaggerSchema: await asyncJsonRequest(extensionSwaggerSchemaUrl),
+    swaggerSchema: await asyncJsonRequest(swaggerSchemaAltUrl),
+    exampleSchema: await asyncJsonRequest(exampleSchemaUrl),
+    compositeSchema: await asyncJsonRequest(compositeSchemaUrl)
+  };
+  let validator = new z({ breakOnFirstError: false });
+  validator.setRemoteReference(swaggerSchemaUrl, context.swaggerSchema);
+  validator.setRemoteReference(exampleSchemaUrl, context.exampleSchema);
+  validator.setRemoteReference(compositeSchemaUrl, context.compositeSchema);
+  context.validator = validator;
+  return context;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,62 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "es2017",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "./dist",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "incremental": true,                   /* Enable incremental compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  }
+}


### PR DESCRIPTION
This's a copy of `breaking-change` and `momentOfTruth` scripts from https://github.com/Azure/azure-rest-api-specs

Here's an example of how it will replace these existing scripts in 'azure-rest-api-spec' repo: 
https://github.com/Azure/azure-rest-api-specs/pull/5660/checks
https://dev.azure.com/azure-sdk/public/_build/results?buildId=18496