### PR TITLE
Revert OAV to earlier version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/rest-api-specs-scripts",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Scripts for the Azure RestAPI specification repository 'azure-rest-api-specs'.",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
@@ -40,7 +40,7 @@
     "fs-extra": "^7.0.1",
     "glob": "^7.1.3",
     "js-yaml": "^3.13.1",
-    "oav": "^0.19.0",
+    "oav": "^0.18.1",
     "request": "^2.88.0"
   }
 }


### PR DESCRIPTION
There is side effect for validation on discriminator as requried which
may introduce SDK breaking change.