### PR TITLE
chore: Bump OAV version to 0.19.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/rest-api-specs-scripts",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Scripts for the Azure RestAPI specification repository 'azure-rest-api-specs'.",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
@@ -33,14 +33,14 @@
     "typescript": "^3.4.4"
   },
   "dependencies": {
-    "@octokit/rest": "^16.25.0",
     "@azure/avocado": "^0.4.1",
     "@azure/oad": "^0.6.3",
+    "@octokit/rest": "^16.25.0",
     "@ts-common/string-map": "^0.3.0",
     "fs-extra": "^7.0.1",
     "glob": "^7.1.3",
     "js-yaml": "^3.13.1",
-    "oav": "^0.18.1",
+    "oav": "^0.19.4",
     "request": "^2.88.0"
   }
 }


### PR DESCRIPTION

Redo #12 with major version bump for parallel testing prerelease CI